### PR TITLE
Use less absoulte path.

### DIFF
--- a/.github/workflows/osv-scanner-main.yaml
+++ b/.github/workflows/osv-scanner-main.yaml
@@ -48,7 +48,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - name: Generate `package-lock.json` from authorized sources
-        if: ${{ !hashFiles('/package-lock.json') }}
+        if: ${{ !hashFiles('package-lock.json') }}
         run: |
           npm install --package-lock-only
       - name: "Run scanner on existing code and generate Markdown"

--- a/.github/workflows/osv-scanner-pr.yaml
+++ b/.github/workflows/osv-scanner-pr.yaml
@@ -46,7 +46,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - name: Generate `package-lock.json`
-        if: ${{ !hashFiles('/package-lock.json') }}
+        if: ${{ !hashFiles('package-lock.json') }}
         run: |
           npm install --package-lock-only
       - name: "Run scanner on existing code and generate Markdown"


### PR DESCRIPTION
hashFiles paths are relative to the git workspace. We currently only
scan the top-level `package-lock.json` (as we do not typically do
mono-repos).
