### PR TITLE
Add npm audit and list output to OSV PR comments.

### DIFF
--- a/.github/actions/npm-audit-list/action.yaml
+++ b/.github/actions/npm-audit-list/action.yaml
@@ -1,3 +1,6 @@
+# Copyright 2025 Digital Bazaar, Inc.
+# SPDX-License-Identifier: BSD-3-Clause
+
 name: Output npm audit and list results as Markdown
 description: >
   A reusable action to output `npm audit` and a filtered `npm list` (based on

--- a/.github/actions/npm-audit-list/action.yaml
+++ b/.github/actions/npm-audit-list/action.yaml
@@ -8,12 +8,14 @@ runs:
     # Run `npm audit` and collect as JSON
     - name: npm audit
       id: npm_audit
+      shell: bash
       run: |
         echo 'result=$(npm audit --json)' >> $GITHUB_OUTPUT
       continue-on-error: true
     # Use `jq` to create a Markdown table of the findings
     - name: npm audit
       id: audit_report
+      shell: bash
       run: |
         AUDIT=$(echo "${{ toJson(steps.npm_audit.outputs.result) }}" | jq -r '
           "| Severity | Name | Version | Fix Available |",
@@ -30,6 +32,7 @@ runs:
     # Generate a tree/list based on the vulnerable package names
     - name: npm list vulnerable dependencies
       id: list_report
+      shell: bash
       run: |
         DEPS=$(echo "${{ toJSON(steps.npm_audit.outputs.result) }}" | jq -r '[.vulnerabilities | to_entries[] | .key] | join(" ")')
         LIST=$(npm list $DEPS --json | jq -r '
@@ -52,6 +55,7 @@ runs:
       # Combine the two Markdown reports into one for use elsewhere
     - name: combine npm audit/list reports
       id: combined_report
+      shell: bash
       run: |
         # Use a random delimiter to capture the multi-line output
         delimiter=$(openssl rand -hex 8)

--- a/.github/actions/npm-audit-list/action.yaml
+++ b/.github/actions/npm-audit-list/action.yaml
@@ -60,13 +60,12 @@ runs:
         # Use a random delimiter to capture the multi-line output
         delimiter=$(openssl rand -hex 8)
         echo "result<<$delimiter" >> $GITHUB_OUTPUT
-        echo "
-          ### npm audit
+        echo "### npm audit
 
-          ${{ steps.audit_report.outputs.result }}
+        ${{ steps.audit_report.outputs.result }}
 
-          ### npm list
+        ### npm list
 
-          ${{ steps.list_report.outputs.result }}
+        ${{ steps.list_report.outputs.result }}
         " >> $GITHUB_OUTPUT
         echo "$delimiter" >> $GITHUB_OUTPUT

--- a/.github/actions/npm-audit-list/action.yaml
+++ b/.github/actions/npm-audit-list/action.yaml
@@ -1,0 +1,68 @@
+name: Output npm audit and list results as Markdown
+description: >
+  A reusable action to output `npm audit` and a filtered `npm list` (based on
+  the audit results) in Markdown.
+runs:
+  using: composite
+  steps:
+    # Run `npm audit` and collect as JSON
+    - name: npm audit
+      id: npm_audit
+      run: |
+        echo 'result=$(npm audit --json)' >> $GITHUB_OUTPUT
+      continue-on-error: true
+    # Use `jq` to create a Markdown table of the findings
+    - name: npm audit
+      id: audit_report
+      run: |
+        AUDIT=$(echo "${{ toJson(steps.npm_audit.outputs.result) }}" | jq -r '
+          "| Severity | Name | Version | Fix Available |",
+          "| --- | --- | --- | --- |",
+          (.vulnerabilities | to_entries | .[] |
+            "| \(.value.severity) | \(.key) | \(.value.range) | \(.value.fixAvailable.version) |"
+          )')
+        # Use a random delimiter to capture the multi-line output
+        delimiter=$(openssl rand -hex 8)
+        echo "result<<$delimiter" >> $GITHUB_OUTPUT
+        echo "$AUDIT" >> $GITHUB_OUTPUT
+        echo "$delimiter" >> $GITHUB_OUTPUT
+      continue-on-error: true
+    # Generate a tree/list based on the vulnerable package names
+    - name: npm list vulnerable dependencies
+      id: list_report
+      run: |
+        DEPS=$(echo "${{ toJSON(steps.npm_audit.outputs.result) }}" | jq -r '[.vulnerabilities | to_entries[] | .key] | join(" ")')
+        LIST=$(npm list $DEPS --json | jq -r '
+          def walk_tree(prefix):
+            to_entries | map(
+              "\(prefix)\(.key)@\(.value.version)\n" +
+              if .value.dependencies then
+                (.value.dependencies | walk_tree("  " + prefix))
+              else
+                ""
+              end
+            ) | join("");
+          .dependencies | walk_tree("* ")')
+        # Use a random delimiter to capture the multi-line output
+        delimiter=$(openssl rand -hex 8)
+        echo "result<<$delimiter" >> $GITHUB_OUTPUT
+        echo "$LIST" >> $GITHUB_OUTPUT
+        echo "$delimiter" >> $GITHUB_OUTPUT
+      continue-on-error: true
+      # Combine the two Markdown reports into one for use elsewhere
+    - name: combine npm audit/list reports
+      id: combined_report
+      run: |
+        # Use a random delimiter to capture the multi-line output
+        delimiter=$(openssl rand -hex 8)
+        echo "result<<$delimiter" >> $GITHUB_OUTPUT
+        echo "
+          ### npm audit
+
+          ${{ steps.audit_report.outputs.result }}
+
+          ### npm list
+
+          ${{ steps.list_report.outputs.result }}
+        " >> $GITHUB_OUTPUT
+        echo "$delimiter" >> $GITHUB_OUTPUT

--- a/.github/actions/npm-audit-list/action.yaml
+++ b/.github/actions/npm-audit-list/action.yaml
@@ -35,7 +35,7 @@ runs:
       shell: bash
       run: |
         DEPS=$(echo "${{ toJSON(steps.npm_audit.outputs.result) }}" | jq -r '[.vulnerabilities | to_entries[] | .key] | join(" ")')
-        LIST=$(npm list $DEPS --json | jq -r '
+        LIST=$(npm list $DEPS --json --package-lock-only | jq -r '
           def walk_tree(prefix):
             to_entries | map(
               "\(prefix)\(.key)@\(.value.version)\n" +

--- a/.github/actions/npm-audit-list/action.yaml
+++ b/.github/actions/npm-audit-list/action.yaml
@@ -2,6 +2,10 @@ name: Output npm audit and list results as Markdown
 description: >
   A reusable action to output `npm audit` and a filtered `npm list` (based on
   the audit results) in Markdown.
+outputs:
+  result:
+    description: Combined npm audit/list reports
+    value: ${{ steps.combined_report.outputs.result }}
 runs:
   using: composite
   steps:

--- a/.github/workflows/osv-scanner-pr.yaml
+++ b/.github/workflows/osv-scanner-pr.yaml
@@ -72,6 +72,7 @@ jobs:
       - name: Generate npm audit and list report
         id: old_audit_list_report
         uses: ./.github/actions/npm-audit-list
+        continue-on-error: true # this action may not exist in the repo yet...
 
       # --- run the same on the current branch ---
       - name: "Checkout current branch"

--- a/.github/workflows/osv-scanner-pr.yaml
+++ b/.github/workflows/osv-scanner-pr.yaml
@@ -100,12 +100,75 @@ jobs:
         uses: juliangruber/read-file-action@b549046febe0fe86f8cb4f93c24e284433f9ab58 # v1.1.7
         with:
           path: new-results.md
-      - name: Add OSV comment
+
+      # Run npm audit and npm list to build up additional report explanations
+      - name: npm audit
+        id: npm_audit
+        run: |
+          echo 'result=$(npm audit --json)' >> $GITHUB_OUTPUT
+        continue-on-error: true
+      - name: npm audit
+        id: audit_report
+        run: |
+          AUDIT=$(echo "${{ toJson(steps.npm_audit.outputs.result) }}" | jq -r '
+            "| Severity | Name | Version | Fix Available |",
+            "| --- | --- | --- | --- |",
+            (.vulnerabilities | to_entries | .[] |
+              "| \(.value.severity) | \(.key) | \(.value.range) | \(.value.fixAvailable.version) |"
+            )')
+          # Use a random delimiter to capture the multi-line output
+          delimiter=$(openssl rand -hex 8)
+          echo "result<<$delimiter" >> $GITHUB_OUTPUT
+          echo "$AUDIT" >> $GITHUB_OUTPUT
+          echo "$delimiter" >> $GITHUB_OUTPUT
+        continue-on-error: true
+      - name: npm list vulnerable dependencies
+        id: list_report
+        run: |
+          DEPS=$(echo "${{ toJSON(steps.npm_audit.outputs.result) }}" | jq -r '[.vulnerabilities | to_entries[] | .key] | join(" ")')
+          LIST=$(npm list $DEPS --json | jq -r '
+            def walk_tree(prefix):
+              to_entries | map(
+                "\(prefix)\(.key)@\(.value.version)\n" +
+                if .value.dependencies then
+                  (.value.dependencies | walk_tree("  " + prefix))
+                else
+                  ""
+                end
+              ) | join("");
+            .dependencies | walk_tree("* ")')
+          # Use a random delimiter to capture the multi-line output
+          delimiter=$(openssl rand -hex 8)
+          echo "result<<$delimiter" >> $GITHUB_OUTPUT
+          echo "$LIST" >> $GITHUB_OUTPUT
+          echo "$delimiter" >> $GITHUB_OUTPUT
+        continue-on-error: true
+
+      # Combine OSV, npm audit, and npm list output into a single comment
+      - name: Add a comment containing OSV, npm audit, and npm list output
         uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
         with:
           message: |
             ## Vulnerability results from base branch
             ${{ steps.old.outputs.content }}
 
+            ### npm audit
+
+            ${{ steps.audit_report.outputs.result }}
+
+            ### npm list
+
+            ${{ steps.list_report.outputs.result }}
+
+            ---
+
             ## Vulnerability results from current PR branch
             ${{ steps.new.outputs.content }}
+
+            ### npm audit
+
+            ${{ steps.audit_report.outputs.result }}
+
+            ### npm list
+
+            ${{ steps.list_report.outputs.result }}

--- a/.github/workflows/osv-scanner-pr.yaml
+++ b/.github/workflows/osv-scanner-pr.yaml
@@ -143,6 +143,22 @@ jobs:
           echo "$LIST" >> $GITHUB_OUTPUT
           echo "$delimiter" >> $GITHUB_OUTPUT
         continue-on-error: true
+      - name: combine npm audit/list reports
+        id: combined_report
+        run: |
+          # Use a random delimiter to capture the multi-line output
+          delimiter=$(openssl rand -hex 8)
+          echo "result<<$delimiter" >> $GITHUB_OUTPUT
+          echo "
+            ### npm audit
+
+            ${{ steps.audit_report.outputs.result }}
+
+            ### npm list
+
+            ${{ steps.list_report.outputs.result }}
+          " >> $GITHUB_OUTPUT
+          echo "$delimiter" >> $GITHUB_OUTPUT
 
       # Combine OSV, npm audit, and npm list output into a single comment
       - name: Add a comment containing OSV, npm audit, and npm list output
@@ -152,23 +168,10 @@ jobs:
             ## Vulnerability results from base branch
             ${{ steps.old.outputs.content }}
 
-            ### npm audit
-
-            ${{ steps.audit_report.outputs.result }}
-
-            ### npm list
-
-            ${{ steps.list_report.outputs.result }}
-
+            ${{ steps.combined_report.outputs.result }}
             ---
 
             ## Vulnerability results from current PR branch
             ${{ steps.new.outputs.content }}
 
-            ### npm audit
-
-            ${{ steps.audit_report.outputs.result }}
-
-            ### npm list
-
-            ${{ steps.list_report.outputs.result }}
+            ${{ steps.combined_report.outputs.result }}

--- a/.github/workflows/osv-scanner-pr.yaml
+++ b/.github/workflows/osv-scanner-pr.yaml
@@ -68,6 +68,12 @@ jobs:
         uses: juliangruber/read-file-action@b549046febe0fe86f8cb4f93c24e284433f9ab58 # v1.1.7
         with:
           path: old-results.md
+      # Run npm audit and npm list to build up additional report explanations
+      - name: Generate npm audit and list report
+        id: old_audit_list_report
+        uses: ./.github/actions/npm-audit-list
+
+      # --- run the same on the current branch ---
       - name: "Checkout current branch"
         # Use -f in case any changes were made by osv-scanner (there should be no changes)
         run: |
@@ -102,63 +108,9 @@ jobs:
           path: new-results.md
 
       # Run npm audit and npm list to build up additional report explanations
-      - name: npm audit
-        id: npm_audit
-        run: |
-          echo 'result=$(npm audit --json)' >> $GITHUB_OUTPUT
-        continue-on-error: true
-      - name: npm audit
-        id: audit_report
-        run: |
-          AUDIT=$(echo "${{ toJson(steps.npm_audit.outputs.result) }}" | jq -r '
-            "| Severity | Name | Version | Fix Available |",
-            "| --- | --- | --- | --- |",
-            (.vulnerabilities | to_entries | .[] |
-              "| \(.value.severity) | \(.key) | \(.value.range) | \(.value.fixAvailable.version) |"
-            )')
-          # Use a random delimiter to capture the multi-line output
-          delimiter=$(openssl rand -hex 8)
-          echo "result<<$delimiter" >> $GITHUB_OUTPUT
-          echo "$AUDIT" >> $GITHUB_OUTPUT
-          echo "$delimiter" >> $GITHUB_OUTPUT
-        continue-on-error: true
-      - name: npm list vulnerable dependencies
-        id: list_report
-        run: |
-          DEPS=$(echo "${{ toJSON(steps.npm_audit.outputs.result) }}" | jq -r '[.vulnerabilities | to_entries[] | .key] | join(" ")')
-          LIST=$(npm list $DEPS --json | jq -r '
-            def walk_tree(prefix):
-              to_entries | map(
-                "\(prefix)\(.key)@\(.value.version)\n" +
-                if .value.dependencies then
-                  (.value.dependencies | walk_tree("  " + prefix))
-                else
-                  ""
-                end
-              ) | join("");
-            .dependencies | walk_tree("* ")')
-          # Use a random delimiter to capture the multi-line output
-          delimiter=$(openssl rand -hex 8)
-          echo "result<<$delimiter" >> $GITHUB_OUTPUT
-          echo "$LIST" >> $GITHUB_OUTPUT
-          echo "$delimiter" >> $GITHUB_OUTPUT
-        continue-on-error: true
-      - name: combine npm audit/list reports
-        id: combined_report
-        run: |
-          # Use a random delimiter to capture the multi-line output
-          delimiter=$(openssl rand -hex 8)
-          echo "result<<$delimiter" >> $GITHUB_OUTPUT
-          echo "
-            ### npm audit
-
-            ${{ steps.audit_report.outputs.result }}
-
-            ### npm list
-
-            ${{ steps.list_report.outputs.result }}
-          " >> $GITHUB_OUTPUT
-          echo "$delimiter" >> $GITHUB_OUTPUT
+      - name: Generate npm audit and list report
+        id: new_audit_list_report
+        uses: ./.github/actions/npm-audit-list
 
       # Combine OSV, npm audit, and npm list output into a single comment
       - name: Add a comment containing OSV, npm audit, and npm list output
@@ -168,10 +120,10 @@ jobs:
             ## Vulnerability results from base branch
             ${{ steps.old.outputs.content }}
 
-            ${{ steps.combined_report.outputs.result }}
+            ${{ steps.old_audit_list_report.outputs.result }}
             ---
 
             ## Vulnerability results from current PR branch
             ${{ steps.new.outputs.content }}
 
-            ${{ steps.combined_report.outputs.result }}
+            ${{ steps.new_audit_list_report.outputs.result }}


### PR DESCRIPTION
This PR is to address @davidlehn's concerns around developers not knowing how to find the correct replacements for a vulnerable dependency. In addition to the CVE links provided by OSV (which have been there from the beginning), the scanner now also provides an `npm audit` report showing available replacement versions as well as an `npm list` result filtered on the vulnerable dependencies for the frequent case when the vulnerability is in a secondary (or "lower") dependency.

Hopefully this helps ease developer research time and speeds resolution of vulnerability issues.